### PR TITLE
Bubble up model loading errors to user

### DIFF
--- a/mac/FreeChat/Models/NPC/Agent.swift
+++ b/mac/FreeChat/Models/NPC/Agent.swift
@@ -52,7 +52,7 @@ class Agent: ObservableObject {
 
     pendingMessage = ""
 
-    let response = try! await llama.complete(
+    let response = try await llama.complete(
       prompt: prompt, stop: template.stopWords, temperature: temperature
     ) { partialResponse in
       DispatchQueue.main.async {


### PR DESCRIPTION
If you load a model that's bigger than your RAM (starling-lm-7b-alpha.Q6_K.gguf on my 8GB Mac), and ask it to generate text, it hangs for a while then crashes the app. This way it should at least show an error message to the user (don't mind the tab bar, idk how that got there. It somehow appeared when I was trying to modify the tab hiding code and now I can't get rid of it, but it's not from this change):

<img width="1012" alt="Screenshot 2023-12-19 at 02 20 51" src="https://github.com/psugihara/FreeChat/assets/5687998/af02b599-eb47-416f-9689-687cbb52d4fa">
