### PR TITLE
Remote server demo

### DIFF
--- a/mac/FreeChat.xcodeproj/project.pbxproj
+++ b/mac/FreeChat.xcodeproj/project.pbxproj
@@ -58,6 +58,7 @@
 		A1F617582A7836AE00F2048C /* Message+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1F617572A7836AE00F2048C /* Message+Extensions.swift */; };
 		A1F6175B2A7838F700F2048C /* Conversation+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1F6175A2A7838F700F2048C /* Conversation+Extensions.swift */; };
 		DEA8CF572B51938B007A4CE7 /* FreeChatAppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEA8CF562B51938B007A4CE7 /* FreeChatAppDelegate.swift */; };
+		DEEA39CC2B586F3800992592 /* ServerHealth.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEEA39CB2B586F3800992592 /* ServerHealth.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -174,6 +175,7 @@
 		A1F617572A7836AE00F2048C /* Message+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Message+Extensions.swift"; sourceTree = "<group>"; };
 		A1F6175A2A7838F700F2048C /* Conversation+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Conversation+Extensions.swift"; sourceTree = "<group>"; };
 		DEA8CF562B51938B007A4CE7 /* FreeChatAppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FreeChatAppDelegate.swift; sourceTree = "<group>"; };
+		DEEA39CB2B586F3800992592 /* ServerHealth.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerHealth.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -255,6 +257,8 @@
 				A137A3872AB502DB00BE1AE0 /* ggml-metal.metal */,
 				A17A2E122A79A005006CDD90 /* Agent.swift */,
 				A17A2E132A79A005006CDD90 /* LlamaServer.swift */,
+				DEEA39C92B586DEA00992592 /* LlamaServerProvider.swift */,
+				DEEA39CB2B586F3800992592 /* RemoteServer.swift */,
 				A137A3822AB4FD4800BE1AE0 /* freechat-server */,
 				A1A286F32A7E17750004967A /* server-watchdog */,
 				A1A286F92A7E197F0004967A /* README.md */,
@@ -564,6 +568,7 @@
 				A1506D742B0026B4002194F2 /* FeedbackButton.swift in Sources */,
 				A12FAAF02AC638DE006ACC43 /* DownloadManager.swift in Sources */,
 				A18A8BAF2B155FC000D2197C /* Network.swift in Sources */,
+				DEEA39CA2B586DEA00992592 /* LlamaServerProvider.swift in Sources */,
 				A1F617282A782AA100F2048C /* ContentView.swift in Sources */,
 				A1F617322A782AA200F2048C /* Chats.xcdatamodeld in Sources */,
 				A1A286E82A7D8A7D0004967A /* MessageView.swift in Sources */,
@@ -582,6 +587,7 @@
 				A13C8C662A9027A200EC18D8 /* CopyButton.swift in Sources */,
 				A17A2E182A79A006006CDD90 /* Agent.swift in Sources */,
 				A12FAAEC2AC5E0C0006ACC43 /* WelcomeSheet.swift in Sources */,
+				DEEA39CC2B586F3800992592 /* RemoteServer.swift in Sources */,
 				A1156D382AD5E75A00081313 /* EnumMap.swift in Sources */,
 				A137A37C2AB3D26C00BE1AE0 /* ObservableScrollView.swift in Sources */,
 				A16FFF8B2B2E35D200E6AAE2 /* GPU.swift in Sources */,
@@ -638,6 +644,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "server-watchdog.entitlements";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_INJECT_BASE_ENTITLEMENTS = NO;
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = 6577JALN5F;

--- a/mac/FreeChat/Models/NPC/Agent.swift
+++ b/mac/FreeChat/Models/NPC/Agent.swift
@@ -33,7 +33,7 @@ class Agent: ObservableObject {
     self.id = id
     self.prompt = prompt
     self.systemPrompt = systemPrompt
-    llama = LlamaServer(modelPath: modelPath, contextLength: contextLength, tls: false, host: nil, port: nil)
+    llama = LlamaServer(modelPath: modelPath, contextLength: contextLength)
   }
 
   // this is the main loop of the agent

--- a/mac/FreeChat/Models/NPC/Agent.swift
+++ b/mac/FreeChat/Models/NPC/Agent.swift
@@ -33,7 +33,7 @@ class Agent: ObservableObject {
     self.id = id
     self.prompt = prompt
     self.systemPrompt = systemPrompt
-    llama = LlamaServer(modelPath: modelPath, contextLength: contextLength)
+    llama = LlamaServer(modelPath: modelPath, contextLength: contextLength, host: nil, port: nil)
   }
 
   // this is the main loop of the agent

--- a/mac/FreeChat/Models/NPC/Agent.swift
+++ b/mac/FreeChat/Models/NPC/Agent.swift
@@ -33,7 +33,7 @@ class Agent: ObservableObject {
     self.id = id
     self.prompt = prompt
     self.systemPrompt = systemPrompt
-    llama = LlamaServer(modelPath: modelPath, contextLength: contextLength, host: nil, port: nil)
+    llama = LlamaServer(modelPath: modelPath, contextLength: contextLength, tls: false, host: nil, port: nil)
   }
 
   // this is the main loop of the agent

--- a/mac/FreeChat/Models/NPC/LlamaServer.swift
+++ b/mac/FreeChat/Models/NPC/LlamaServer.swift
@@ -39,15 +39,15 @@ actor LlamaServer {
   private var eventSource: EventSource?
   private let host: String
   private let port: String
-  // TODO: Use URL initializer
-  //private let scheme: String = "http"
+  private let scheme: String
   private var interrupted = false
 
   private var monitor = Process()
 
-  init(modelPath: String, contextLength: Int, host: String?, port: String?) {
+  init(modelPath: String, contextLength: Int, tls: Bool, host: String?, port: String?) {
     self.modelPath = modelPath
     self.contextLength = contextLength
+    self.scheme = tls ? "https" : "http"
     self.host = host ?? "127.0.0.1"
     self.port = port ?? "8690"
   }
@@ -170,7 +170,7 @@ actor LlamaServer {
     )
     if let t = temperature { params.temperature = t }
 
-    let url = URL(string: "http://\(host):\(port)/completion")!
+    let url = URL(string: "\(scheme)://\(host):\(port)/completion")!
     var request = URLRequest(url: url)
 
     request.httpMethod = "POST"

--- a/mac/FreeChat/Models/NPC/LlamaServer.swift
+++ b/mac/FreeChat/Models/NPC/LlamaServer.swift
@@ -37,14 +37,19 @@ actor LlamaServer {
   private var serverUp = false
   private var serverErrorMessage = ""
   private var eventSource: EventSource?
-  private let port = "8690"
+  private let host: String
+  private let port: String
+  // TODO: Use URL initializer
+  //private let scheme: String = "http"
   private var interrupted = false
 
   private var monitor = Process()
 
-  init(modelPath: String, contextLength: Int) {
+  init(modelPath: String, contextLength: Int, host: String?, port: String?) {
     self.modelPath = modelPath
     self.contextLength = contextLength
+    self.host = host ?? "127.0.0.1"
+    self.port = port ?? "8690"
   }
 
   // Start a monitor process that will terminate the server when our app dies.
@@ -165,7 +170,7 @@ actor LlamaServer {
     )
     if let t = temperature { params.temperature = t }
 
-    let url = URL(string: "http://127.0.0.1:\(port)/completion")!
+    let url = URL(string: "http://\(host):\(port)/completion")!
     var request = URLRequest(url: url)
 
     request.httpMethod = "POST"

--- a/mac/FreeChat/Models/NPC/PromptTemplates/TemplateManager.swift
+++ b/mac/FreeChat/Models/NPC/PromptTemplates/TemplateManager.swift
@@ -75,17 +75,4 @@ struct TemplateManager {
     
     return .vicuna
   }
-
-  static func formatTitle(_ format: TemplateFormat) -> String {
-    switch format {
-      case .alpaca:
-        "Alpaca"
-      case .chatML:
-        "ChatML"
-      case .llama2:
-        "Llama 2"
-      case .vicuna:
-        "Vicuna"
-    }
-  }
 }

--- a/mac/FreeChat/Models/NPC/PromptTemplates/Templates.swift
+++ b/mac/FreeChat/Models/NPC/PromptTemplates/Templates.swift
@@ -8,10 +8,10 @@
 import Foundation
 
 enum TemplateFormat: String, CaseIterable {
-  case llama2
-  case chatML
-  case alpaca
-  case vicuna
+  case llama2 = "Llama 2"
+  case chatML = "ChatML"
+  case alpaca = "Alpaca"
+  case vicuna = "Vicuna"
 }
 
 protocol Template {

--- a/mac/FreeChat/Models/NPC/ServerHealth.swift
+++ b/mac/FreeChat/Models/NPC/ServerHealth.swift
@@ -1,0 +1,72 @@
+//
+//  ServerHealth.swift
+//  FreeChat
+//
+
+import Foundation
+
+fileprivate struct ServerHealthRequest {
+
+  enum ServerHealthError: Error {
+    case invalidResponse
+  }
+
+  func checkOK(url: URL) async throws -> Bool {
+    let config = URLSessionConfiguration.default
+    config.timeoutIntervalForRequest = 3
+    config.timeoutIntervalForResource = 1
+    let (data, response) = try await URLSession(configuration: config).data(from: url)
+    guard let responseCode = (response as? HTTPURLResponse)?.statusCode,
+          responseCode > 0
+    else { throw ServerHealthError.invalidResponse }
+
+    guard let json = try JSONSerialization.jsonObject(with: data, options: []) as? [String: String],
+          let jsonStatus: String = json["status"]
+    else { throw ServerHealthError.invalidResponse }
+
+    return responseCode == 200 && jsonStatus == "ok"
+  }
+}
+
+@globalActor
+actor ServerHealth {
+
+  static let shared = ServerHealth()
+
+  private var url: URL?
+  private var healthRequest = ServerHealthRequest()
+  private var bucket: [Double?] = Array(repeating: nil, count: 15) // last responses
+  private var bucketIndex = 0
+  private let thresholdMilli = 0.3 // with serialization
+  private var bucketValues: [Double] { bucket.compactMap({ $0 }) }
+  var score: Double {
+    bucketValues.reduce(0, +) / Double(bucketValues.count)
+  }
+
+  func updateURL(_ newURL: URL?) {
+    self.url = newURL
+    self.bucket.removeAll(keepingCapacity: true)
+    self.bucket = Array(repeating: nil, count: 15)
+  }
+
+  func check() async {
+    guard let url = self.url else { return }
+    let startTime = CFAbsoluteTimeGetCurrent()
+    do {
+      let resOK = try await healthRequest.checkOK(url: url)
+      let delta = CFAbsoluteTimeGetCurrent() - startTime
+      let deltaV = (1 - (delta - thresholdMilli) / thresholdMilli)
+      let deltaW = (deltaV > 1 ? 1 : deltaV) * 0.25
+      let resW = (resOK ? 1 : 0) * 0.75
+      putScore(resW + deltaW)
+    } catch {
+      print("error requesting url \(url.absoluteString): ", error)
+      putScore(0)
+    }
+  }
+
+  private func putScore(_ newScore: Double) {
+    bucket[bucketIndex] = newScore
+    bucketIndex = (bucketIndex + 1) % bucket.count
+  }
+}

--- a/mac/FreeChat/Views/ConversationView/ConversationView.swift
+++ b/mac/FreeChat/Views/ConversationView/ConversationView.swift
@@ -42,9 +42,8 @@ struct ConversationView: View, Sendable {
   }
 
   var selectedModel: Model? {
-    // TODO: Refactor
-    if let selectedModelId = self.selectedModelId,
-       selectedModelId != AISettingsView.remoteModelOption {
+    if selectedModelId != AISettingsView.remoteModelOption,
+      let selectedModelId = self.selectedModelId {
       models.first(where: { $0.id?.uuidString == selectedModelId })
     } else {
       models.first
@@ -147,32 +146,39 @@ struct ConversationView: View, Sendable {
 
     messages = c.orderedMessages
         
-    // TODO: Refactor
-    if selectedModelId == AISettingsView.remoteModelOption {
-      Task {
-        await agent.llama.stopServer()
-        agent.llama = LlamaServer(modelPath: "", contextLength: contextLength, tls: serverTLS ?? false, host: serverHost, port: serverPort)
-      }
-    }
 
     // warmup the agent if it's cold or model has changed
     Task {
-      guard let id = UUID(uuidString: selectedModelId) else { return }
-      let req = Model.fetchRequest()
-      req.predicate = NSPredicate(format: "id == %@", id as CVarArg)
-      let llamaPath = await agent.llama.modelPath
-
-      if let models = try? viewContext.fetch(req),
-        let model = models.first,
-        let modelPath = model.url?.path(percentEncoded: false),
-        modelPath != llamaPath {
-        await agent.llama.stopServer()
-        agent.llama = LlamaServer(modelPath: modelPath, contextLength: contextLength, tls: serverTLS ?? false, host: serverHost, port: serverPort)
-  //        try? await agent.warmup(template: model.template)
-      } else if agent.status == .cold {
-//        try? await agent.warmup()
+      if selectedModelId == AISettingsView.remoteModelOption {
+        await initializeServerRemote()
+      } else {
+        await initializeServerLocal(modelId: selectedModelId)
       }
     }
+  }
+
+  private func initializeServerLocal(modelId: String) async {
+    guard let id = UUID(uuidString: modelId)
+    else { return }
+    
+    let llamaPath = await agent.llama.modelPath
+    let req = Model.fetchRequest()
+    req.predicate = NSPredicate(format: "id == %@", id as CVarArg)
+    if let model = try? viewContext.fetch(req).first,
+       let modelPath = model.url?.path(percentEncoded: false),
+       modelPath != llamaPath {
+      await agent.llama.stopServer()
+      agent.llama = LlamaServer(modelPath: modelPath, contextLength: contextLength)
+    }
+  }
+
+  private func initializeServerRemote() async {
+    guard let tls = serverTLS,
+          let host = serverHost,
+          let port = serverPort
+    else { return }
+    await agent.llama.stopServer()
+    agent.llama = LlamaServer(contextLength: contextLength, tls: tls, host: host, port: port)
   }
 
   private func scrollToLastIfRecent(_ proxy: ScrollViewProxy) {

--- a/mac/FreeChat/Views/ConversationView/ConversationView.swift
+++ b/mac/FreeChat/Views/ConversationView/ConversationView.swift
@@ -19,6 +19,8 @@ struct ConversationView: View, Sendable {
   @AppStorage("playSoundEffects") private var playSoundEffects = true
   @AppStorage("temperature") private var temperature: Double?
   @AppStorage("useGPU") private var useGPU: Bool = Agent.DEFAULT_USE_GPU
+  @AppStorage("serverHost") private var serverHost: String?
+  @AppStorage("serverPort") private var serverPort: String?
 
   @FetchRequest(
     sortDescriptors: [NSSortDescriptor(keyPath: \Model.size, ascending: true)],
@@ -153,8 +155,8 @@ struct ConversationView: View, Sendable {
         let model = models.first,
         let modelPath = model.url?.path(percentEncoded: false),
         modelPath != llamaPath {
-          await agent.llama.stopServer()
-        agent.llama = LlamaServer(modelPath: modelPath, contextLength: contextLength)
+        await agent.llama.stopServer()
+        agent.llama = LlamaServer(modelPath: modelPath, contextLength: contextLength, host: serverHost, port: serverPort)
   //        try? await agent.warmup(template: model.template)
       } else if agent.status == .cold {
 //        try? await agent.warmup()

--- a/mac/FreeChat/Views/Settings/AISettingsView.swift
+++ b/mac/FreeChat/Views/Settings/AISettingsView.swift
@@ -31,6 +31,7 @@ struct AISettingsView: View {
   @AppStorage("serverTLS") private var serverTLS: Bool = false
   @AppStorage("serverHost") private var serverHost: String?
   @AppStorage("serverPort") private var serverPort: String?
+  @AppStorage("remoteModelTemplate") var remoteModelTemplate: String?
 
   @State var pickedModel: String? // Picker selection
   @State var customizeModels = false // Show add remove models
@@ -148,20 +149,29 @@ struct AISettingsView: View {
         .fixedSize(horizontal: false, vertical: true)
         .padding(.top, 0.5)
 
-      if let model = selectedModel {
-        HStack {
-          Text("Prompt format: \(TemplateManager.formatTitle(model.template.format))")
+      HStack {
+        if let model = selectedModel {
+          Text("Prompt format: \(model.template.format.rawValue)")
             .foregroundColor(Color(NSColor.secondaryLabelColor))
             .font(.caption)
-          Button("Edit") {
-            editFormat = true
-          }.buttonStyle(.link).font(.caption)
-            .offset(x: -4)
+        } else if editRemoteModel {
+          Text("Prompt format: \(remoteModelTemplate ?? TemplateFormat.vicuna.rawValue)")
+            .foregroundColor(Color(NSColor.secondaryLabelColor))
+            .font(.caption)
         }
-          .sheet(isPresented: $editFormat, content: {
-          EditFormat(model: model)
-        })
+        Button("Edit") {
+          editFormat = true
+        }
+        .buttonStyle(.link).font(.caption)
+          .offset(x: -4)
       }
+      .sheet(isPresented: $editFormat, content: {
+        if let model = selectedModel {
+          EditFormat(model: model)
+        } else if editRemoteModel {
+          EditFormat(modelName: "Remote")
+        }
+      })
     }
   }
 

--- a/mac/FreeChat/Views/Settings/AISettingsView.swift
+++ b/mac/FreeChat/Views/Settings/AISettingsView.swift
@@ -142,13 +142,15 @@ struct AISettingsView: View {
  
       }
 
-      Text("The default model is general purpose, small, and works on most computers. Larger models are slower but wiser. Some models specialize in certain tasks like coding Python. FreeChat is compatible with most models in GGUF format. [Find new models](https://huggingface.co/models?search=GGUF)")
-        .font(.callout)
-        .foregroundColor(Color(NSColor.secondaryLabelColor))
-        .lineLimit(5)
-        .fixedSize(horizontal: false, vertical: true)
-        .padding(.top, 0.5)
-
+      if !editRemoteModel {
+        Text("The default model is general purpose, small, and works on most computers. Larger models are slower but wiser. Some models specialize in certain tasks like coding Python. FreeChat is compatible with most models in GGUF format. [Find new models](https://huggingface.co/models?search=GGUF)")
+          .font(.callout)
+          .foregroundColor(Color(NSColor.secondaryLabelColor))
+          .lineLimit(5)
+          .fixedSize(horizontal: false, vertical: true)
+          .padding(.top, 0.5)
+      }
+      
       HStack {
         if let model = selectedModel {
           Text("Prompt format: \(model.template.format.rawValue)")
@@ -236,16 +238,16 @@ struct AISettingsView: View {
         .fixedSize(horizontal: false, vertical: true)
         .padding(.top, 0.5)
       HStack {
-        TextField("Server Host", text: $inputServerHost)
+        TextField("Server host", text: $inputServerHost, prompt: Text("yourserver.net"))
           .textFieldStyle(.plain)
           .font(.callout)
-        TextField("Server Port", text: $inputServerPort)
+        TextField("Server port", text: $inputServerPort, prompt: Text("3000"))
           .textFieldStyle(.plain)
           .font(.callout)
        Spacer()
       }
       Toggle(isOn: $inputServerTLS) {
-        Text("Secure Connection (HTTPS)")
+        Text("Secure connection (HTTPS)")
           .font(.callout)
       }
       HStack {
@@ -281,15 +283,17 @@ struct AISettingsView: View {
               .padding(.top, 2.5)
               .padding(.bottom, 4)
 
-            Divider()
+            if !editRemoteModel {
+              Divider()
 
-            HStack {
-              Text("Context Length")
-              TextField("", value: $contextLength, formatter: contextLengthFormatter)
-                .padding(.vertical, -8)
-                .padding(.trailing, -10)
+              HStack {
+                Text("Context Length")
+                TextField("", value: $contextLength, formatter: contextLengthFormatter)
+                  .padding(.vertical, -8)
+                  .padding(.trailing, -10)
+              }
+              .padding(.top, 0.5)
             }
-            .padding(.top, 0.5)
 
             Divider()
 
@@ -302,7 +306,7 @@ struct AISettingsView: View {
                 .frame(width: 24, alignment: .trailing)
             }.padding(.top, 1)
 
-            if gpu.available {
+            if gpu.available && !editRemoteModel {
               Divider()
 
               Toggle("Use GPU Acceleration", isOn: $useGPU).padding(.top, 1)

--- a/mac/FreeChat/Views/Settings/AISettingsView.swift
+++ b/mac/FreeChat/Views/Settings/AISettingsView.swift
@@ -182,6 +182,9 @@ struct AISettingsView: View {
     inputServerPort != serverPort ||
     inputServerTLS != serverTLS
   }
+  var hasRemoteConnectionError: Bool {
+    serverHealthScore < 0.25 && serverHealthScore >= 0
+  }
 
   var indicatorColor: Color {
     switch serverHealthScore {
@@ -211,7 +214,7 @@ struct AISettingsView: View {
           case 0.75...1:
             Text("Connected")
           case 0..<0.75:
-            Text("Connection Error")
+            Text("Connection Error. Retrying...")
           default:
             Text("Not Connected")
           }
@@ -254,7 +257,7 @@ struct AISettingsView: View {
         serverHealthIndication
         Spacer()
         Button("Apply", action: saveFormRemoteServer)
-          .disabled(!hasRemoteServerInputChanged)
+          .disabled(!hasRemoteServerInputChanged && !hasRemoteConnectionError)
       }
     }
   }

--- a/mac/FreeChat/Views/Settings/EditFormat.swift
+++ b/mac/FreeChat/Views/Settings/EditFormat.swift
@@ -11,35 +11,57 @@ struct EditFormat: View {
   @Environment(\.dismiss) var dismiss
   @Environment(\.managedObjectContext) var viewContext
 
-  @State var selection: TemplateFormat?
-  
-  var model: Model
-  
+  @AppStorage("remoteModelTemplate") var remoteModelTemplate: String?
+  @State private var selection: TemplateFormat?
+
+  private var modelID: UUID? // For local models only
+  private var modelName: String?
+  private var modelTemplate: String?
+
+  init(model: Model) {
+    self.modelID = model.id
+    self.modelName = model.name
+    self.modelTemplate = model.promptTemplate
+ }
+
+  init(modelName: String) {
+    self.modelID = nil
+    self.modelName = modelName
+    self.modelTemplate = remoteModelTemplate
+  }
+
+  var templateText: String {
+    let format = selection ?? TemplateManager.formatFromModel(modelName)
+    let template = TemplateManager.templates[format]
+    return template.run(systemPrompt: "{{system prompt}}", messages: ["hi, bot"]).trimmingCharacters(in: .whitespacesAndNewlines)
+  }
+
   var body: some View {
     VStack(alignment: .leading) {
       Text("Prompt format").font(.body)
-      if let modelName = model.name {
-        Text("for \(modelName)").font(.caption).foregroundStyle(.secondary)
+      if let modelName = self.modelName {
+        Text("for \(modelName)")
+          .font(.caption).foregroundStyle(.secondary)
       }
       Picker("", selection: $selection) {
-        Format(TemplateManager.formatFromModel(model.name), title: "Auto (\(TemplateManager.formatTitle(TemplateManager.formatFromModel(model.name))))")
+        Format(TemplateManager.formatFromModel(modelName), title: "Auto (\(TemplateManager.formatFromModel(modelName).rawValue))")
         ForEach(TemplateFormat.allCases, id: \.self) { format in
-          Format(format, title: TemplateManager.formatTitle(format))
+          Format(format, title: format.rawValue)
         }
       }
       .padding(.top, 8)
       .pickerStyle(.menu)
-        .labelsHidden()
-        .onChange(of: selection) { next in
-          model.promptTemplate = next?.rawValue
-          do {
-            try viewContext.save()
-          } catch {
-            print("Error saving prompt template: \(error.localizedDescription)")
-          }
+      .labelsHidden()
+      .onChange(of: selection) { next in
+        guard let template = next?.rawValue else { return }
+        if let modelID = self.modelID {
+          saveTemplate(modelID: modelID, template: template)
+        } else {
+          saveTemplate(template: template)
         }
+      }
 
-      Text(templateText())
+      Text(templateText)
         .foregroundColor(.secondary)
         .font(.monospaced(.caption)())
         .padding(.vertical, 6)
@@ -52,31 +74,47 @@ struct EditFormat: View {
 
       Button("Done") {
         dismiss()
-      }.frame(maxWidth: .infinity, alignment: .trailing)
-        .padding(.top, 10)
-        .keyboardShortcut(.defaultAction)
-    }.padding()
-      .padding(.horizontal, 2)
-      .onAppear() {
-        if selection == nil, let templateName = model.promptTemplate {
+      }
+      .frame(maxWidth: .infinity, alignment: .trailing)
+      .padding(.top, 10)
+      .keyboardShortcut(.defaultAction)
+    }
+    .padding()
+    .padding(.horizontal, 2)
+    .onAppear() {
+        if selection == nil, let templateName = modelTemplate {
           selection = TemplateFormat(rawValue: templateName)
         }
       }
       .frame(minWidth: 360, maxWidth: 400)
   }
-  
+
   func Format(_ format: TemplateFormat, title: String) -> some View {
-    return VStack(alignment: .leading) {
+    VStack(alignment: .leading) {
       Text(title)
-    }.padding(.vertical, 4)
-      .id(title)
-      .tag(title.hasPrefix("Auto ") ? nil : format)
+    }
+    .padding(.vertical, 4)
+    .id(title)
+    .tag(title.hasPrefix("Auto ") ? nil : format)
   }
 
-  func templateText() -> String {
-    let format = selection ?? TemplateManager.formatFromModel(model.name)
-    let template = TemplateManager.templates[format]
-    return template.run(systemPrompt: "{{system prompt}}", messages: ["hi, bot"]).trimmingCharacters(in: .whitespacesAndNewlines)
+  private func saveTemplate(modelID: UUID, template: String) {
+    let req = Model.fetchRequest()
+    req.predicate = NSPredicate(format: "id == %@", modelID as CVarArg)
+    do {
+      if let model = try viewContext.fetch(req).first {
+        model.promptTemplate = template
+        try viewContext.save()
+      } else {
+        print("Error finding model with id \(modelID)")
+      }
+    } catch {
+      print("Error saving prompt template: \(error.localizedDescription)")
+    }
+  }
+
+  private func saveTemplate(template: String) {
+    remoteModelTemplate = template
   }
 }
 

--- a/mac/FreeChat/Views/Settings/SettingsView.swift
+++ b/mac/FreeChat/Views/Settings/SettingsView.swift
@@ -18,13 +18,13 @@ struct SettingsView: View {
     TabView {
       UISettingsView()
         .tabItem {
-        Label("General", systemImage: "gear")
-      }
+          Label("General", systemImage: "gear")
+        }
         .tag(Tabs.ui)
       AISettingsView()
         .tabItem {
-        Label("Intelligence", systemImage: "hands.and.sparkles.fill")
-      }
+          Label("Intelligence", systemImage: "hands.and.sparkles.fill")
+        }
         .tag(Tabs.ai)
     }
       .frame(minWidth: 300, maxWidth: 600, minHeight: 184, idealHeight: 195, maxHeight: 400, alignment: .center)


### PR DESCRIPTION
I tried it with a remote server and it works pretty well. 

The app requires a model to be loaded first before using it, although it doesn't need a model if configured with a remote server. But for UX it is good to have the chat always available with a fallback model.

Maybe should be a boolean / chekbox value to indicate that the user uses a remote server, and enable / disable remote server config in the settings.

- [x] Onboarding without a model.
- [x] Settings UX. 
- [x] Switch between servers during conversation.

Closes https://github.com/psugihara/FreeChat/issues/28