### PR TITLE
Added font size option to settings and updated message view

### DIFF
--- a/mac/FreeChat/Views/ConversationView/ConversationView.swift
+++ b/mac/FreeChat/Views/ConversationView/ConversationView.swift
@@ -22,6 +22,7 @@ struct ConversationView: View, Sendable {
   @AppStorage("serverHost") private var serverHost: String?
   @AppStorage("serverPort") private var serverPort: String?
   @AppStorage("serverTLS") private var serverTLS: Bool?
+  @AppStorage("fontSizeOption") private var fontSizeOption: Int = 12
 
   @FetchRequest(
     sortDescriptors: [NSSortDescriptor(keyPath: \Model.size, ascending: true)],
@@ -106,6 +107,7 @@ struct ConversationView: View, Sendable {
       }
     }
       .textSelection(.enabled)
+      .font(.system(size:CGFloat( fontSizeOption)))
       .safeAreaInset(edge: .bottom, spacing: 0) {
       MessageTextField { s in
         submit(s)

--- a/mac/FreeChat/Views/ConversationView/MessageView.swift
+++ b/mac/FreeChat/Views/ConversationView/MessageView.swift
@@ -183,7 +183,7 @@ struct MessageView: View {
         Group {
           if m.fromId == Message.USER_SPEAKER_ID {
             Text(messageText)
-                  .font(.system(size:CGFloat( fontSizeOption)))
+             .font(.system(size:CGFloat( fontSizeOption)))
           } else {
             Markdown(messageText)
               .markdownTheme(.freeChat)

--- a/mac/FreeChat/Views/ConversationView/MessageView.swift
+++ b/mac/FreeChat/Views/ConversationView/MessageView.swift
@@ -22,6 +22,10 @@ struct MessageView: View {
   @State var isHover = false
   @State var animateDots = false
 
+  @AppStorage("fontSizeOption") private var fontSizeOption: Int = 12
+    
+    
+    
   init(_ m: Message, overrideText: String = "", agentStatus: Agent.Status?) {
     self.m = m
     self.overrideText = overrideText
@@ -40,6 +44,7 @@ struct MessageView: View {
       ? Text("warming up...")
     : Text(m.createdAt ?? Date(), formatter: messageTimestampFormatter))
       .font(.caption)
+      .font(.system(size:CGFloat( fontSizeOption)))
   }
 
   var info: String {
@@ -178,6 +183,7 @@ struct MessageView: View {
         Group {
           if m.fromId == Message.USER_SPEAKER_ID {
             Text(messageText)
+                  .font(.system(size:CGFloat( fontSizeOption)))
           } else {
             Markdown(messageText)
               .markdownTheme(.freeChat)

--- a/mac/FreeChat/Views/Markdown/Theme+FreeChat.swift
+++ b/mac/FreeChat/Views/Markdown/Theme+FreeChat.swift
@@ -22,10 +22,15 @@ extension Theme {
   /// Bulleted list | ![](GitHubNestedBulletedList)
   /// Numbered list | ![](GitHubNumberedList)
   /// Table | ![](GitHubTable)
+    ///
+  @AppStorage("fontSizeOption") private static var fontSizeOption: Int = 12
+        
+    
   public static let freeChat = Theme()
     .text {
       ForegroundColor(.text)
       BackgroundColor(.background)
+      FontSize(CGFloat(fontSizeOption))
     }
     .code {
       FontFamilyVariant(.monospaced)

--- a/mac/FreeChat/Views/Markdown/Theme+FreeChat.swift
+++ b/mac/FreeChat/Views/Markdown/Theme+FreeChat.swift
@@ -26,158 +26,160 @@ extension Theme {
   @AppStorage("fontSizeOption") private static var fontSizeOption: Int = 12
         
     
-  public static let freeChat = Theme()
-    .text {
-      ForegroundColor(.text)
-      BackgroundColor(.background)
-      FontSize(CGFloat(fontSizeOption))
-    }
-    .code {
-      FontFamilyVariant(.monospaced)
-      FontSize(.em(0.85))
-      BackgroundColor(.secondaryBackground)
-    }
-    .strong {
-      FontWeight(.semibold)
-    }
-    .link {
-      ForegroundColor(.link)
-    }
-    .heading1 { configuration in
-      VStack(alignment: .leading, spacing: 0) {
-        configuration.label
-          .relativePadding(.bottom, length: .em(0.3))
-          .relativeLineSpacing(.em(0.125))
-          .markdownMargin(top: 24, bottom: 16)
-          .markdownTextStyle {
-            FontWeight(.semibold)
-            FontSize(.em(2))
-          }
-        Divider().overlay(Color.divider)
-      }
-    }
-    .heading2 { configuration in
-      VStack(alignment: .leading, spacing: 0) {
-        configuration.label
-          .relativePadding(.bottom, length: .em(0.3))
-          .relativeLineSpacing(.em(0.125))
-          .markdownMargin(top: 24, bottom: 16)
-          .markdownTextStyle {
-            FontWeight(.semibold)
-            FontSize(.em(1.5))
-          }
-        Divider().overlay(Color.divider)
-      }
-    }
-    .heading3 { configuration in
-      configuration.label
-        .relativeLineSpacing(.em(0.125))
-        .markdownMargin(top: 24, bottom: 16)
-        .markdownTextStyle {
-          FontWeight(.semibold)
-          FontSize(.em(1.25))
-        }
-    }
-    .heading4 { configuration in
-      configuration.label
-        .relativeLineSpacing(.em(0.125))
-        .markdownMargin(top: 24, bottom: 16)
-        .markdownTextStyle {
-          FontWeight(.semibold)
-        }
-    }
-    .heading5 { configuration in
-      configuration.label
-        .relativeLineSpacing(.em(0.125))
-        .markdownMargin(top: 24, bottom: 16)
-        .markdownTextStyle {
-          FontWeight(.semibold)
-          FontSize(.em(0.875))
-        }
-    }
-    .heading6 { configuration in
-      configuration.label
-        .relativeLineSpacing(.em(0.125))
-        .markdownMargin(top: 24, bottom: 16)
-        .markdownTextStyle {
-          FontWeight(.semibold)
-          FontSize(.em(0.85))
-          ForegroundColor(.tertiaryText)
-        }
-    }
-    .paragraph { configuration in
-      configuration.label
-        .fixedSize(horizontal: false, vertical: true)
-        .relativeLineSpacing(.em(0.25))
-        .markdownMargin(top: 0, bottom: 16)
-    }
-    .blockquote { configuration in
-      HStack(spacing: 0) {
-        RoundedRectangle(cornerRadius: 6, style: .continuous)
-          .fill(Color.border)
-          .relativeFrame(width: .em(0.2))
-        configuration.label
-          .markdownTextStyle { ForegroundColor(.secondaryText) }
-          .relativePadding(.horizontal, length: .em(1))
-      }
-      .fixedSize(horizontal: false, vertical: true)
-    }
-    .codeBlock { configuration in
-      ZStack(alignment: .topTrailing) {
-        ScrollView(.horizontal) {
-          configuration.label
-            .relativeLineSpacing(.em(0.225))
-            .markdownTextStyle {
-              FontFamilyVariant(.monospaced)
-              FontSize(.em(0.85))
+    public static var freeChat: Theme {
+        Theme()
+            .text {
+                ForegroundColor(.text)
+                BackgroundColor(.background)
+                FontSize(CGFloat(fontSizeOption))
             }
-            .padding(16)
-        }
-        .background(Color.secondaryBackground)
-        .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
-        .markdownMargin(top: 0, bottom: 16)
-       
-        CopyButton(text: configuration.content).padding(10)
-      }
-    }
-    .listItem { configuration in
-      configuration.label
-        .markdownMargin(top: .em(0.25))
-    }
-    .taskListMarker { configuration in
-      Image(systemName: configuration.isCompleted ? "checkmark.square.fill" : "square")
-        .symbolRenderingMode(.hierarchical)
-        .foregroundStyle(Color.checkbox, Color.checkboxBackground)
-        .imageScale(.small)
-        .relativeFrame(minWidth: .em(1.5), alignment: .trailing)
-    }
-    .table { configuration in
-      configuration.label
-        .fixedSize(horizontal: false, vertical: true)
-        .markdownTableBorderStyle(.init(color: .border))
-        .markdownTableBackgroundStyle(
-          .alternatingRows(Color.background, Color.secondaryBackground)
-        )
-        .markdownMargin(top: 0, bottom: 16)
-    }
-    .tableCell { configuration in
-      configuration.label
-        .markdownTextStyle {
-          if configuration.row == 0 {
-            FontWeight(.semibold)
-          }
-          BackgroundColor(nil)
-        }
-        .fixedSize(horizontal: false, vertical: true)
-        .padding(.vertical, 6)
-        .padding(.horizontal, 13)
-        .relativeLineSpacing(.em(0.25))
-    }
-    .thematicBreak {
-      Divider()
-        .relativeFrame(height: .em(0.25))
-        .overlay(Color.border)
-        .markdownMargin(top: 24, bottom: 24)
+            .code {
+                FontFamilyVariant(.monospaced)
+                FontSize(.em(0.85))
+                BackgroundColor(.secondaryBackground)
+            }
+            .strong {
+                FontWeight(.semibold)
+            }
+            .link {
+                ForegroundColor(.link)
+            }
+            .heading1 { configuration in
+                VStack(alignment: .leading, spacing: 0) {
+                    configuration.label
+                        .relativePadding(.bottom, length: .em(0.3))
+                        .relativeLineSpacing(.em(0.125))
+                        .markdownMargin(top: 24, bottom: 16)
+                        .markdownTextStyle {
+                            FontWeight(.semibold)
+                            FontSize(.em(2))
+                        }
+                    Divider().overlay(Color.divider)
+                }
+            }
+            .heading2 { configuration in
+                VStack(alignment: .leading, spacing: 0) {
+                    configuration.label
+                        .relativePadding(.bottom, length: .em(0.3))
+                        .relativeLineSpacing(.em(0.125))
+                        .markdownMargin(top: 24, bottom: 16)
+                        .markdownTextStyle {
+                            FontWeight(.semibold)
+                            FontSize(.em(1.5))
+                        }
+                    Divider().overlay(Color.divider)
+                }
+            }
+            .heading3 { configuration in
+                configuration.label
+                    .relativeLineSpacing(.em(0.125))
+                    .markdownMargin(top: 24, bottom: 16)
+                    .markdownTextStyle {
+                        FontWeight(.semibold)
+                        FontSize(.em(1.25))
+                    }
+            }
+            .heading4 { configuration in
+                configuration.label
+                    .relativeLineSpacing(.em(0.125))
+                    .markdownMargin(top: 24, bottom: 16)
+                    .markdownTextStyle {
+                        FontWeight(.semibold)
+                    }
+            }
+            .heading5 { configuration in
+                configuration.label
+                    .relativeLineSpacing(.em(0.125))
+                    .markdownMargin(top: 24, bottom: 16)
+                    .markdownTextStyle {
+                        FontWeight(.semibold)
+                        FontSize(.em(0.875))
+                    }
+            }
+            .heading6 { configuration in
+                configuration.label
+                    .relativeLineSpacing(.em(0.125))
+                    .markdownMargin(top: 24, bottom: 16)
+                    .markdownTextStyle {
+                        FontWeight(.semibold)
+                        FontSize(.em(0.85))
+                        ForegroundColor(.tertiaryText)
+                    }
+            }
+            .paragraph { configuration in
+                configuration.label
+                    .fixedSize(horizontal: false, vertical: true)
+                    .relativeLineSpacing(.em(0.25))
+                    .markdownMargin(top: 0, bottom: 16)
+            }
+            .blockquote { configuration in
+                HStack(spacing: 0) {
+                    RoundedRectangle(cornerRadius: 6, style: .continuous)
+                        .fill(Color.border)
+                        .relativeFrame(width: .em(0.2))
+                    configuration.label
+                        .markdownTextStyle { ForegroundColor(.secondaryText) }
+                        .relativePadding(.horizontal, length: .em(1))
+                }
+                .fixedSize(horizontal: false, vertical: true)
+            }
+            .codeBlock { configuration in
+                ZStack(alignment: .topTrailing) {
+                    ScrollView(.horizontal) {
+                        configuration.label
+                            .relativeLineSpacing(.em(0.225))
+                            .markdownTextStyle {
+                                FontFamilyVariant(.monospaced)
+                                FontSize(.em(0.85))
+                            }
+                            .padding(16)
+                    }
+                    .background(Color.secondaryBackground)
+                    .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
+                    .markdownMargin(top: 0, bottom: 16)
+                    
+                    CopyButton(text: configuration.content).padding(10)
+                }
+            }
+            .listItem { configuration in
+                configuration.label
+                    .markdownMargin(top: .em(0.25))
+            }
+            .taskListMarker { configuration in
+                Image(systemName: configuration.isCompleted ? "checkmark.square.fill" : "square")
+                    .symbolRenderingMode(.hierarchical)
+                    .foregroundStyle(Color.checkbox, Color.checkboxBackground)
+                    .imageScale(.small)
+                    .relativeFrame(minWidth: .em(1.5), alignment: .trailing)
+            }
+            .table { configuration in
+                configuration.label
+                    .fixedSize(horizontal: false, vertical: true)
+                    .markdownTableBorderStyle(.init(color: .border))
+                    .markdownTableBackgroundStyle(
+                        .alternatingRows(Color.background, Color.secondaryBackground)
+                    )
+                    .markdownMargin(top: 0, bottom: 16)
+            }
+            .tableCell { configuration in
+                configuration.label
+                    .markdownTextStyle {
+                        if configuration.row == 0 {
+                            FontWeight(.semibold)
+                        }
+                        BackgroundColor(nil)
+                    }
+                    .fixedSize(horizontal: false, vertical: true)
+                    .padding(.vertical, 6)
+                    .padding(.horizontal, 13)
+                    .relativeLineSpacing(.em(0.25))
+            }
+            .thematicBreak {
+                Divider()
+                    .relativeFrame(height: .em(0.25))
+                    .overlay(Color.border)
+                    .markdownMargin(top: 24, bottom: 24)
+            }
     }
 }
 

--- a/mac/FreeChat/Views/Settings/UISettingsView.swift
+++ b/mac/FreeChat/Views/Settings/UISettingsView.swift
@@ -16,7 +16,10 @@ struct UISettingsView: View {
 
   @AppStorage("playSoundEffects") private var playSoundEffects = true
   @AppStorage("showFeedbackButtons") private var showFeedbackButtons = true
-
+  @AppStorage("fontSizeOption") private var fontSizeOption: Double = 12
+  
+    
+    
   var globalHotkey: some View {
     KeyboardShortcuts.Recorder("Summon chat", name: .summonFreeChat)
   }
@@ -37,11 +40,21 @@ struct UISettingsView: View {
     }
   }
 
+  var fontSizeOptions: some View {
+      HStack(alignment: /*@START_MENU_TOKEN@*/.center/*@END_MENU_TOKEN@*/, content: {
+          Text("Font size: \(String(format: "%.0f", fontSizeOption))")
+               
+          Slider(value: $fontSizeOption, in: 10...30, step: 1)
+                     .padding()
+      })
+  }
+    
   var body: some View {
     Form {
       globalHotkey
       soundEffects
       feedbackButtons
+      fontSizeOptions
     }
       .formStyle(.grouped)
       .frame(minWidth: 300, maxWidth: 600, minHeight: 184, idealHeight: 195, maxHeight: 400, alignment: .center)


### PR DESCRIPTION
Added a simple slider in the settings and updated the message view to size the text. The font size only applies to the text in the messages, not all text

<img width="1157" alt="image" src="https://github.com/psugihara/FreeChat/assets/40506329/fca2902a-7338-42ee-870a-6e857d8c4864">


<img width="1157" alt="image" src="https://github.com/psugihara/FreeChat/assets/40506329/4ddb19ce-0054-49b2-bb73-046fd162c4b3">


(Just FYI - This is my first development in Swift, first time using Xcode and I'm about 4 hours in, so I expect I got stuff wrong but it works) 

